### PR TITLE
Allow an ets_lru to be completely disabled

### DIFF
--- a/src/ets_lru.erl
+++ b/src/ets_lru.erl
@@ -326,11 +326,11 @@ next_timeout(St) ->
 
 set_options(St, []) ->
     St;
-set_options(St, [{max_objects, N} | Rest]) when is_integer(N), N > 0 ->
+set_options(St, [{max_objects, N} | Rest]) when is_integer(N), N >= 0 ->
     set_options(St#st{max_objs=N}, Rest);
-set_options(St, [{max_size, N} | Rest]) when is_integer(N), N > 0 ->
+set_options(St, [{max_size, N} | Rest]) when is_integer(N), N >= 0 ->
     set_options(St#st{max_size=N}, Rest);
-set_options(St, [{max_lifetime, N} | Rest]) when is_integer(N), N > 0 ->
+set_options(St, [{max_lifetime, N} | Rest]) when is_integer(N), N >= 0 ->
     set_options(St#st{max_lifetime=N}, Rest);
 set_options(_, [Opt | _]) ->
     throw({invalid_option, Opt}).


### PR DESCRIPTION
## Overview
Currently it is impossible to disable the ddoc_cache by specifying `-ddoc_cache max_objects 0` in `vm.args`. This allows such a configuration, paired with a similar change in `ddoc_cache`.

## Testing recommendations
Add `-ddoc_cache max_objects 0` in `vm.args` and start up couch. It should run correctly.

## GitHub issue number

Related to apache/couchdb#559 but does not fix it.

## Related Pull Requests

https://github.com/apache/couchdb/pull/561

## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
