### PR TITLE
Remove unused var in tests

### DIFF
--- a/test/ets_lru_test.erl
+++ b/test/ets_lru_test.erl
@@ -169,7 +169,7 @@ lru_bad_options_test_() ->
                 process_flag(trap_exit,true),
                 ets_lru:start_link(?MODULE, Opts)
             end,
-            fun(_, Cfg) ->
+            fun(_, _) ->
                 case whereis(?MODULE) of
                     Pid when is_pid(Pid) ->
                         stop_lru({ok, Pid});


### PR DESCRIPTION
Trivial fix to remove a variable in one of the tests' teardown function to avoid "Unused variable" warning.